### PR TITLE
fix(feishu): group message auth, reply routing, and i18n key regex

### DIFF
--- a/hub-server/channels/feishu.ts
+++ b/hub-server/channels/feishu.ts
@@ -225,7 +225,9 @@ async function handleMessage(event: Record<string, unknown>): Promise<void> {
   if (!senderId || !chatId) return;
 
   // Check allowlist — 非主人拒收 + push system 告警（统一 4 通道模式）
-  if (!isAllowed(senderId)) {
+  // 群消息：群 chat_id (oc_) 在白名单即视为授权（群成员无需单独加白名单）
+  const isGroupMessage = chatId.startsWith("oc_");
+  if (!isAllowed(senderId) && !(isGroupMessage && isAllowed(chatId))) {
     const rawPreview = (event.content ?? "") as string;
     hub.logError(`⛔ 拒绝未授权: ${senderName} (${senderId}), 原文前 50: "${rawPreview.slice(0, 50)}"`);
     hub.pushMessage({
@@ -242,15 +244,15 @@ async function handleMessage(event: Record<string, unknown>): Promise<void> {
   const messageId = (event.message_id ?? event.id ?? "") as string;
   let content = (event.content ?? "") as string;
 
-  // Compact mode: image key is in content as "[Image: img_v3_xxx]"
-  const imageKeyMatch = content.match(/\[Image:\s*(img_[^\]]+)\]/);
+  // Compact mode: image key is in content as "[Image: img_v3_xxx]" or "[图片: img_v3_xxx]"
+  const imageKeyMatch = content.match(/\[(?:Image|图片):\s*(img_[^\]]+)\]/);
   if (imageKeyMatch && messageId) {
     const imageKey = imageKeyMatch[1];
     const filePath = downloadFeishuMedia(messageId, "image", imageKey);
     content = filePath ? `[图片] ${filePath}` : `[图片: ${imageKey}]`;
   } else if (msgType === "file" && messageId) {
     // Compact mode: file key might be in content as "[File: file_v3_xxx]"
-    const fileKeyMatch = content.match(/\[File:\s*(file_[^\]]+)\]/);
+    const fileKeyMatch = content.match(/\[(?:File|文件):\s*(file_[^\]]+)\]/);
     const fileKey = fileKeyMatch?.[1] ?? (event.file_key ?? "") as string;
     const fileName = (event.file_name ?? "file") as string;
     if (fileKey) {
@@ -283,12 +285,14 @@ async function handleMessage(event: Record<string, unknown>): Promise<void> {
   const displayName = getNickname(senderId) || senderName;
   hub.log(`← ${displayName}: ${content.slice(0, 80)}${content.length > 80 ? "..." : ""}`);
 
+  // 群消息用 chat_id (oc_) 作为 fromId，这样 reply 会发到群里而不是私聊
+  const replyTo = chatId.startsWith("oc_") ? chatId : senderId;
   hub.pushMessage({
     channel: "feishu",
     from: displayName,
-    fromId: senderId,
+    fromId: replyTo,
     content,
-    raw: { sender_id: senderId, message_type: msgType },
+    raw: { sender_id: senderId, chat_id: chatId, message_type: msgType },
   });
 
   // History recorded by Hub layer


### PR DESCRIPTION
## Summary

- **Group authorization**: `oc_` chat_id in allowlist now authorizes all group members — previously, any group member not individually added to the allowlist was blocked with a 403 error even if the group itself was allowed
- **Group reply routing**: Bot replies now go to the group thread (`oc_` chat_id) instead of the sender's private chat
- **Image/file key regex**: Added support for Chinese compact-mode prefixes `[图片: img_v3_xxx]` and `[文件: file_xxx]` alongside existing English patterns

## Root cause

`isAllowed(senderId)` only checked the sender's personal `ou_` id. Group messages have an `oc_` chat_id that was already in the allowlist, but the check never looked at it. Group members were blocked unless each one was individually added.

## Test plan

- [ ] Add a group `oc_` id to `state/feishu/allowlist.json`
- [ ] Send a message from a group member whose personal `ou_` id is NOT in the allowlist
- [ ] Verify message is received and bot reply appears in the group thread
- [ ] Send an image in the group — verify `img_v3_xxx` key is parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)