### PR TITLE
feat: add forge-hub sync — lightweight runtime sync

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -293,6 +293,7 @@ function syncCmd(): void {
 
   // 2. Copy hub-server .ts/.json/.lock files to runtime
   cpDir(serverSrc, HUB_DIR, [".ts", ".json", ".lock"]);
+  cleanDirContents(CHANNELS_RUNTIME);
   cpDir(path.join(serverSrc, "channels"), CHANNELS_RUNTIME, [".ts"]);
 
   // Security: maintain 700 permissions

--- a/cli.ts
+++ b/cli.ts
@@ -282,6 +282,53 @@ function installCmd(): void {
 `);
 }
 
+// ── sync ────────────────────────────────────────────────────────────────────
+
+function syncCmd(): void {
+  log("🔄 Forge Hub sync\n");
+
+  // 1. Re-stage package snapshot from current source
+  const packageRoot = stagePackageRuntime();
+  const serverSrc = path.join(packageRoot, "hub-server");
+
+  // 2. Copy hub-server .ts/.json/.lock files to runtime
+  cpDir(serverSrc, HUB_DIR, [".ts", ".json", ".lock"]);
+  cpDir(path.join(serverSrc, "channels"), CHANNELS_RUNTIME, [".ts"]);
+
+  // Security: maintain 700 permissions
+  try {
+    fs.chmodSync(HUB_DIR, 0o700);
+    fs.chmodSync(CHANNELS_RUNTIME, 0o700);
+  } catch (err) {
+    console.warn(`⚠️  chmod 700 失败: ${String(err)}`);
+  }
+  log("✓ hub-server runtime synced（channels/ 已更新）");
+
+  // 3. Restart hub via launchctl
+  if (os.platform() === "darwin") {
+    const uid = os.userInfo().uid;
+    const label = `gui/${uid}/com.forge-hub`;
+    try {
+      // kickstart -k: forcibly restart by plist path
+      execFileSync("launchctl", ["kickstart", "-k", "-p", LAUNCHD_PLIST], { stdio: "ignore" });
+      log("✓ Hub 已重启");
+    } catch {
+      // Fallback: bootout + bootstrap if kickstart by path fails
+      try {
+        execFileSync("launchctl", ["bootout", label], { stdio: "ignore" });
+      } catch { /* might not be bootstrapped */ }
+      try {
+        execFileSync("launchctl", ["bootstrap", label, LAUNCHD_PLIST], { stdio: "ignore" });
+        log("✓ Hub 已重启");
+      } catch {
+        log(`⚠️  无法重启 Hub。手动执行：launchctl bootout ${label} && launchctl bootstrap ${label} ${LAUNCHD_PLIST}`);
+      }
+    }
+  }
+
+  log("\n✅ Sync 完成。hub-server 运行时已对齐源码。");
+}
+
 // ── uninstall ───────────────────────────────────────────────────────────────
 
 function uninstallCmd(): void {
@@ -680,6 +727,9 @@ if (import.meta.main) {
     case "install":
       installCmd();
       break;
+    case "sync":
+      syncCmd();
+      break;
     case "uninstall":
       uninstallCmd();
       break;
@@ -696,6 +746,7 @@ USAGE:
 
 COMMANDS:
   install      一键部署到 ~/.forge-hub/ + ~/.claude/channels/hub/ + launchd + MCP 注册
+  sync         仅同步 hub-server 运行时文件（git pull 后跑这个，不重装 deps/dashboard）
   uninstall    反向操作（保留 state）
   doctor       诊断 install 状态 + connectivity
   --help       显示此帮助

--- a/cli.ts
+++ b/cli.ts
@@ -47,6 +47,10 @@ export const HUB_INSTALL_PRESERVE_ENTRIES = [
   ".DS_Store",
 ];
 
+// 用户运行时配置——sync 时绝不允许从源码 cpDir 覆盖。
+// （install 走 cleanDirContents preserve set，sync 不 clean 但要防同名 .json 静默覆盖。）
+const SYNC_SKIP = new Set(["hub-config.json", "lock-phrase.json", "lock.json"]);
+
 // 找包根目录（从 cli.ts 的位置反推）
 const PKG_ROOT = path.dirname(fileURLToPath(import.meta.url));
 
@@ -292,7 +296,8 @@ function syncCmd(): void {
   const serverSrc = path.join(packageRoot, "hub-server");
 
   // 2. Copy hub-server .ts/.json/.lock files to runtime
-  cpDir(serverSrc, HUB_DIR, [".ts", ".json", ".lock"]);
+  //    SYNC_SKIP 防止 hub-server/ 下未来若出现同名 .json 静默覆盖用户运行时配置（hub-config.json 等）。
+  cpDir(serverSrc, HUB_DIR, [".ts", ".json", ".lock"], SYNC_SKIP);
   cleanDirContents(CHANNELS_RUNTIME);
   cpDir(path.join(serverSrc, "channels"), CHANNELS_RUNTIME, [".ts"]);
 
@@ -306,24 +311,20 @@ function syncCmd(): void {
   log("✓ hub-server runtime synced（channels/ 已更新）");
 
   // 3. Restart hub via launchctl
+  //    复用 installCmd 的 bootout + bootstrap 模式（kickstart -k -p 不是合法 launchctl 语法；
+  //    bootstrap 第一参数是 domain 不是完整 label）。
   if (os.platform() === "darwin") {
     const uid = os.userInfo().uid;
-    const label = `gui/${uid}/com.forge-hub`;
+    const domain = `gui/${uid}`;
+    const label = `${domain}/com.forge-hub`;
     try {
-      // kickstart -k: forcibly restart by plist path
-      execFileSync("launchctl", ["kickstart", "-k", "-p", LAUNCHD_PLIST], { stdio: "ignore" });
+      execFileSync("launchctl", ["bootout", label], { stdio: "ignore" });
+    } catch { /* might not be bootstrapped */ }
+    try {
+      execFileSync("launchctl", ["bootstrap", domain, LAUNCHD_PLIST], { stdio: "inherit" });
       log("✓ Hub 已重启");
     } catch {
-      // Fallback: bootout + bootstrap if kickstart by path fails
-      try {
-        execFileSync("launchctl", ["bootout", label], { stdio: "ignore" });
-      } catch { /* might not be bootstrapped */ }
-      try {
-        execFileSync("launchctl", ["bootstrap", label, LAUNCHD_PLIST], { stdio: "ignore" });
-        log("✓ Hub 已重启");
-      } catch {
-        log(`⚠️  无法重启 Hub。手动执行：launchctl bootout ${label} && launchctl bootstrap ${label} ${LAUNCHD_PLIST}`);
-      }
+      log(`⚠️  无法重启 Hub。手动执行：launchctl bootout ${label} && launchctl bootstrap ${domain} ${LAUNCHD_PLIST}`);
     }
   }
 
@@ -484,10 +485,11 @@ async function doctorCmd(): Promise<void> {
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 
-function cpDir(src: string, dst: string, exts: string[]): void {
+function cpDir(src: string, dst: string, exts: string[], skipNames = new Set<string>()): void {
   if (!fs.existsSync(src)) die(`source 不存在: ${src}`);
   fs.mkdirSync(dst, { recursive: true });
   for (const f of fs.readdirSync(src)) {
+    if (skipNames.has(f)) continue;
     const sp = path.join(src, f);
     const dp = path.join(dst, f);
     const stat = fs.statSync(sp);

--- a/维护地图.md
+++ b/维护地图.md
@@ -158,3 +158,4 @@ Claude Code permission_request
 - 安全相关失败默认 fail closed；如果不能 fail closed，文档和日志必须讲清代价。
 - 安装和运行时路径不要靠记忆，查 [部署.md](部署.md) 和 [运行时状态.md](运行时状态.md)。
 - Preview / experimental 可以探索，但不要让默认安装路径变复杂。
+- **源码更新后跑 `forge-hub sync` 对齐运行时**。git pull / 切换分支后 `~/.forge-hub/` 文件不会自动更新，源码与运行时版本不一致会导致通道插件报错。`forge-hub sync` 只同步 hub-server 源文件 + 重启 Hub，不重装 deps/dashboard/plist/MCP。


### PR DESCRIPTION
## Summary

- Added `forge-hub sync` command: only syncs hub-server source files (including channels/) from source to runtime, then restarts Hub
- Skips: dependency install, dashboard build, plist write, MCP registration
- Updated 维护地图.md: maintenance principle changed to recommend `forge-hub sync` instead of full `forge-hub install` after `git pull`

## Motivation

After `git pull`, `~/.forge-hub/` runtime files don't auto-update. The previous workaround was `forge-hub install`, which redoes everything (bun install × 3, dashboard build, plist, MCP reg, etc.) — slow and unnecessary.

This caused a real outage: `hub.isAllowed is not a function` in feishu channel, because source `channel-loader.ts` added `isAllowed()` to HubAPI but runtime wasn't synced.

## Changes

| File | Change |
|------|--------|
| `cli.ts` | Added `syncCmd()` + wired into dispatch + help text |
| `维护地图.md` | Updated maintenance principle: `forge-hub sync` after source update |

## Self-test

```
$ bun cli.ts doctor
✅ All checks passed

$ bun cli.ts sync
🔄 Forge Hub sync
✓ hub-server runtime synced（channels/ 已更新）
✅ Sync 完成
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)