### PR TITLE
docs(engine): document required `server:engine` channel allowlist flag

### DIFF
--- a/forge-engine/README.md
+++ b/forge-engine/README.md
@@ -63,19 +63,42 @@ bun install
 }
 ```
 
-3. 注册为 Claude Code MCP server（`.claude.json` 或 `claude_desktop_config.json`）：
+3. 注册为 Claude Code MCP server——推荐用 `claude mcp add`（user scope，所有 session 共享）：
+```bash
+claude mcp add --scope user engine /Users/<you>/.bun/bin/bun /absolute/path/to/forge-engine/engine-channel.ts
+```
+
+或手写到 `~/.claude.json` 的 `mcpServers`：
 ```json
 {
   "mcpServers": {
     "engine": {
       "command": "bun",
-      "args": ["path/to/forge-engine/engine-channel.ts"]
+      "args": ["/absolute/path/to/forge-engine/engine-channel.ts"]
     }
   }
 }
 ```
 
-4. 用 `fh engine` 管理任务：
+4. **启动 Claude Code 时把 engine 加入 channels 白名单**——这一步**必不可少**，否则 engine 的定时通知会被 Claude Code 静默丢弃：
+
+```bash
+claude --dangerously-load-development-channels server:hub server:engine
+```
+
+> [!IMPORTANT]
+> Channels 是 research preview（详见 [Channels Reference](https://code.claude.com/docs/en/channels-reference)），自定义 channel server（包括 forge-engine、forge-hub 的 hub-channel）必须用 `--dangerously-load-development-channels server:<name>` 显式白名单才被识别。`claude mcp list` 显示 `✓ Connected` **只代表 MCP 子进程成功启动**，**不代表 channel 通知能投递**——后者还需要这一步。
+>
+> 多 channel 用**空格分隔**：`server:hub server:engine`（不是逗号）。和 forge-hub 一起用时两个都要加。如果你用 [forge-launcher](https://github.com/LinekForge/forge-launcher) 启动菜单栏会话管理器，它会自动带上这俩 flag。
+
+**验证 channel 通知是否真的接通**：
+```bash
+# 在跑 Claude Code 的窗口里让 agent 用 engine_add_task 工具加一个 30 秒后的一次性任务，
+# 如果 30 秒后窗口里收到 <channel source="engine" ...> 包裹的消息，说明白名单生效。
+# 收不到 → 检查是不是漏了 server:engine。
+```
+
+5. 用 `fh engine` 管理任务：
 ```bash
 fh engine list
 fh engine pause 30

--- a/forge-engine/README.md
+++ b/forge-engine/README.md
@@ -63,42 +63,39 @@ bun install
 }
 ```
 
-3. 注册为 Claude Code MCP server——推荐用 `claude mcp add`（user scope，所有 session 共享）：
-```bash
-claude mcp add --scope user engine /Users/<you>/.bun/bin/bun /absolute/path/to/forge-engine/engine-channel.ts
-```
+3. 注册 engine 为 Claude Code 的 MCP server（二选一）：
 
-或手写到 `~/.claude.json` 的 `mcpServers`：
-```json
-{
-  "mcpServers": {
-    "engine": {
-      "command": "bun",
-      "args": ["/absolute/path/to/forge-engine/engine-channel.ts"]
-    }
-  }
-}
-```
+   **方式 A（推荐）**：CLI 一行注册（user scope，所有 session 共享）
+   ```bash
+   claude mcp add --transport stdio --scope user engine -- bun /absolute/path/to/forge-engine/engine-channel.ts
+   ```
+
+   **方式 B**：手写到 `~/.claude.json` 的 `mcpServers`
+   ```json
+   {
+     "mcpServers": {
+       "engine": {
+         "command": "bun",
+         "args": ["/absolute/path/to/forge-engine/engine-channel.ts"]
+       }
+     }
+   }
+   ```
 
 4. **启动 Claude Code 时把 engine 加入 channels 白名单**——这一步**必不可少**，否则 engine 的定时通知会被 Claude Code 静默丢弃：
 
 ```bash
-claude --dangerously-load-development-channels server:hub server:engine
+claude --dangerously-load-development-channels server:engine
 ```
 
 > [!IMPORTANT]
 > Channels 是 research preview（详见 [Channels Reference](https://code.claude.com/docs/en/channels-reference)），自定义 channel server（包括 forge-engine、forge-hub 的 hub-channel）必须用 `--dangerously-load-development-channels server:<name>` 显式白名单才被识别。`claude mcp list` 显示 `✓ Connected` **只代表 MCP 子进程成功启动**，**不代表 channel 通知能投递**——后者还需要这一步。
 >
-> 多 channel 用**空格分隔**：`server:hub server:engine`（不是逗号）。和 forge-hub 一起用时两个都要加。如果你用 [forge-launcher](https://github.com/LinekForge/forge-launcher) 启动菜单栏会话管理器，它会自动带上这俩 flag。
+> 和 forge-hub 一起用要带两个，**空格分隔**：`server:hub server:engine`（不是逗号）。如果你用 [forge-launcher](https://github.com/LinekForge/forge-launcher) 启动菜单栏会话管理器，它会自动带上这俩 flag。
 
-**验证 channel 通知是否真的接通**：
-```bash
-# 在跑 Claude Code 的窗口里让 agent 用 engine_add_task 工具加一个 30 秒后的一次性任务，
-# 如果 30 秒后窗口里收到 <channel source="engine" ...> 包裹的消息，说明白名单生效。
-# 收不到 → 检查是不是漏了 server:engine。
-```
+5. 验证 channel 通知接通：在跑 Claude Code 的窗口里让 agent 调用 `engine_add_task` 工具（设 `delay_seconds: 30`）。30 秒后窗口收到 `<channel source="engine" ...>` 包裹的消息说明白名单生效；收不到 → 检查是否漏了 `server:engine`。
 
-5. 用 `fh engine` 管理任务：
+6. 用 `fh engine` 管理任务：
 ```bash
 fh engine list
 fh engine pause 30


### PR DESCRIPTION
## Summary

- Spell out that `claude --dangerously-load-development-channels server:engine` is required for engine notifications to be delivered. Without it, the MCP subprocess connects fine and the scheduler fires on time, but every notification is silently dropped — easy to mistake for "engine doesn't work" when the root cause is a missing launch flag.
- Show the multi-channel form for users running engine alongside hub: `server:hub server:engine` (space-separated, not comma).
- Add a verification recipe using `engine_add_task` with a 30-second delay so users can confirm the channel notification path end-to-end.
- Cross-link Anthropic's Channels Reference and forge-launcher (which handles the flag automatically).

## Motivation

Real debug session that triggered this: ~1 week of "engine sometimes works, sometimes doesn't" symptoms turned out to be a single missing `server:engine` token in the launching `claude` command. `claude mcp list` showed `✓ Connected` the whole time, which strongly suggested the engine MCP was fine — but the trigger log was the only evidence anything fired, because notifications were dropped by Claude Code's research-preview allowlist. The README didn't mention this flag at all, so users following it would hit the same wall.

## Scope

Docs-only — touches `forge-engine/README.md` only.

## Test plan

- [x] `git -c core.quotepath=false status --short --untracked-files=all` → only `forge-engine/README.md` modified
- [x] secret grep `grep -rE '@im\.wechat|ou_[a-f0-9]{16,}|sk-ant-[a-zA-Z0-9_-]{20,}|sk-[a-zA-Z0-9_-]{20,}|[0-9]{9,10}:[A-Za-z0-9_-]{35}'` → no hits in changed file
- [x] All commands and links in the new section verified to match the current repo (no fictional CLI commands; `claude mcp add --scope user`, `--dangerously-load-development-channels server:<name>`, `engine_add_task` all real)
- [x] Doesn't change any code paths — no harness / self-test needed per CONTRIBUTING.md guidance for docs-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)