### PR TITLE
fix: install/sync 递归拷 hub-server 子目录，根治漏拷 routes/ 致 Hub 100% 崩 (#35)

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -96,7 +96,10 @@ function installCmd(): void {
   cleanDirContents(HUB_DIR, new Set(HUB_INSTALL_PRESERVE_ENTRIES));
   cleanDirContents(CHANNELS_RUNTIME);
   const serverSrc = path.join(packageRoot, "hub-server");
-  cpDir(serverSrc, HUB_DIR, [".ts", ".json", ".lock"]);
+  // 递归拷 hub-server（含 routes/ 及未来任何子目录）——非递归 cpDir 会静默跳过
+  // routes/，导致 endpoints.ts import './routes/health.js' 时 100% 崩（#35）。
+  // channels/ 单独走下面的 clean + chmod 700 路径，故这里排除避免重复拷。
+  copyFilteredTree(serverSrc, HUB_DIR, [".ts", ".json", ".lock"], new Set(["channels"]));
   cpDir(path.join(serverSrc, "channels"), CHANNELS_RUNTIME, [".ts"]);
   // Security (redteam B3): chmod 700 CHANNELS_RUNTIME——防其他 user-level 进程
   // 写入恶意 plugin。fs.watch 已默认关闭（hub-server/channel-loader.ts），
@@ -313,8 +316,10 @@ function syncCmd(): void {
   const serverSrc = path.join(packageRoot, "hub-server");
 
   // 2. Copy hub-server .ts/.json/.lock files to runtime
-  //    SYNC_SKIP 防止 hub-server/ 下未来若出现同名 .json 静默覆盖用户运行时配置（hub-config.json 等）。
-  cpDir(serverSrc, HUB_DIR, [".ts", ".json", ".lock"], SYNC_SKIP);
+  //    递归拷（含 routes/ 及未来任何子目录）——非递归会漏 routes/ 致 Hub 启动崩（#35）。
+  //    SYNC_SKIP 防止 hub-server/ 下同名 .json 静默覆盖用户运行时配置（hub-config.json 等）；
+  //    channels/ 单独 clean + 拷，故一并排除。
+  copyFilteredTree(serverSrc, HUB_DIR, [".ts", ".json", ".lock"], new Set([...SYNC_SKIP, "channels"]));
   cleanDirContents(CHANNELS_RUNTIME);
   cpDir(path.join(serverSrc, "channels"), CHANNELS_RUNTIME, [".ts"]);
 
@@ -445,6 +450,9 @@ async function doctorCmd(): Promise<void> {
 
   check("Bun installed", which("bun") !== null, "https://bun.sh");
   check("Hub server runtime", fs.existsSync(path.join(HUB_DIR, "hub.ts")), "跑 forge-hub install");
+  // routes/ 是 endpoints.ts 启动时 import 的子目录，漏拷则 Hub 100% 崩（#35）。
+  // 单独校验避免 install/sync 漏拷后 doctor 仍报 All checks passed。
+  check("Hub routes/ deployed", fs.existsSync(path.join(HUB_DIR, "routes", "health.ts")), "routes/ 漏拷——跑 forge-hub install/sync 重新部署");
   check("Hub client runtime", fs.existsSync(path.join(HUB_CLIENT_RUNTIME, "hub-channel.ts")), "跑 forge-hub install");
   check("LaunchAgent plist", os.platform() !== "darwin" || fs.existsSync(LAUNCHD_PLIST), "Mac 上跑 forge-hub install");
   check("MCP registered", isMcpRegistered(), "Hub channel 没在 ~/.claude.json");
@@ -524,15 +532,16 @@ export function cleanDirContents(dir: string, preserve = new Set<string>()): voi
   }
 }
 
-function copyFilteredTree(src: string, dst: string, exts: string[]): void {
+function copyFilteredTree(src: string, dst: string, exts: string[], skipNames = new Set<string>()): void {
   if (!fs.existsSync(src)) die(`source 不存在: ${src}`);
   fs.mkdirSync(dst, { recursive: true });
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
     if (entry.name === "node_modules" || entry.name === ".git" || entry.name === "dist") continue;
+    if (skipNames.has(entry.name)) continue;
     const sp = path.join(src, entry.name);
     const dp = path.join(dst, entry.name);
     if (entry.isDirectory()) {
-      copyFilteredTree(sp, dp, exts);
+      copyFilteredTree(sp, dp, exts, skipNames);
       continue;
     }
     if (entry.isFile() && exts.some((ext) => entry.name.endsWith(ext))) {


### PR DESCRIPTION
> 关联 issue：LinekForge/forge-hub #35（#38 是其重复件，已折入 doctor 建议）。

## 为什么
升级到 HEAD 后 `forge-hub install` 完成，但 launchd 拉起的 hub 立即崩：

```
error: Cannot find module './routes/health.js' from '/Users/<...>/.forge-hub/endpoints.ts'
```

根因：`cli.ts` 的 `cpDir` 是**非递归**的（`readdirSync` 一层 + `stat.isFile()`，遇子目录直接跳过）。install/sync 部署 hub-server 时只显式拷了顶层文件 + `channels/`，**漏了 `routes/`**。而 `endpoints.ts` 启动时 `import './routes/health.js'`，运行时缺该目录 → **100% 崩**，KeepAlive 陷崩溃循环刷爆 stderr。`routes/` 是路由拆分后引入的子目录，installer 的硬编码拷贝清单没跟上这次重构。

（注：`stagePackageRuntime` 的 source→snapshot 已用递归 `copyFilteredTree`，故 `package/hub-server/routes/` 完整；漏的是 snapshot→runtime 这一步。）

## 改了什么
- `copyFilteredTree` 增加可选 `skipNames` 参数（与既有 `cpDir` 对齐）。
- install / sync 的 hub-server 拷贝从非递归 `cpDir` 换成递归 `copyFilteredTree`，**排除 `channels/`**（保留其原有 clean + chmod 700 路径），sync 额外保留 `SYNC_SKIP`。这样自动覆盖 `routes/` 及未来任何新增子目录，根治"加子目录忘改 installer"的回归。
- `doctor` 增加 "Hub routes/ deployed" 校验（检 `routes/health.ts`），避免漏拷后仍报 "All checks passed"（采纳 #38 @AmberCXX 的建议）。

## 没改什么
- `channels/` 的 clean + chmod 700 安全路径不动。
- sync 的 `SYNC_SKIP`（防同名 .json 覆盖用户运行时配置）语义不变。
- 不动 `cpDir`（仍用于 hub-client 等顶层拷贝场景）。

## 怎么验
- `bun cli.ts --help` 解析通过（项目无构建步骤，Bun 直跑 TS）。
- 临时 HOME 跑 `bun cli.ts doctor`：缺 `routes/` → ✗「Hub routes/ deployed」并给修复提示；补上 `routes/health.ts` → ✓。
- 复刻补丁后的递归拷贝跑真实 `hub-server`：`routes/` 6 个文件全落、`channels/` 正确排除、顶层文件照拷。
- `bun hub-test-harness/harness.ts`：8/8 通过（无回归）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
